### PR TITLE
Minor bugfixes

### DIFF
--- a/src/generated/resources/data/neapolitan/tags/entity_types/scares_chimpanzees.json
+++ b/src/generated/resources/data/neapolitan/tags/entity_types/scares_chimpanzees.json
@@ -11,6 +11,10 @@
     {
       "id": "caverns_and_chasms:tmt",
       "required": false
+    },
+    {
+      "id": "savage_and_ravage:spore_bomb",
+      "required": false
     }
   ]
 }

--- a/src/main/java/com/teamabnormals/neapolitan/common/item/MilkBottleItem.java
+++ b/src/main/java/com/teamabnormals/neapolitan/common/item/MilkBottleItem.java
@@ -11,6 +11,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.MobEffectEvent;
 
 import java.util.Random;
 
@@ -52,7 +54,9 @@ public class MilkBottleItem extends Item {
 			if (effects.size() > 0) {
 				Random rand = new Random();
 				MobEffectInstance effectToRemove = effects.get(rand.nextInt(effects.size()));
-				entity.removeEffect(effectToRemove.getEffect());
+				if (!MinecraftForge.EVENT_BUS.post(new MobEffectEvent.Remove(entity, effectToRemove.getEffect()))) {
+					entity.removeEffect(effectToRemove.getEffect());
+				}
 			}
 		}
 	}

--- a/src/main/java/com/teamabnormals/neapolitan/core/data/server/tags/NeapolitanEntityTypeTagsProvider.java
+++ b/src/main/java/com/teamabnormals/neapolitan/core/data/server/tags/NeapolitanEntityTypeTagsProvider.java
@@ -25,7 +25,7 @@ public class NeapolitanEntityTypeTagsProvider extends EntityTypeTagsProvider {
 		this.tag(EntityTypeTags.ARROWS).add(NeapolitanEntityTypes.BANANARROW.get());
 
 		this.tag(NeapolitanEntityTypeTags.CHIMPANZEE_DART_TARGETS).addOptional(NeapolitanConstants.BOLLOOM_FRUIT).addOptional(NeapolitanConstants.BOLLOOM_BALLOON);
-		this.tag(NeapolitanEntityTypeTags.SCARES_CHIMPANZEES).add(EntityType.DRAGON_FIREBALL, EntityType.EVOKER_FANGS, EntityType.FIREBALL, EntityType.FIREWORK_ROCKET, EntityType.LIGHTNING_BOLT, EntityType.SMALL_FIREBALL, EntityType.TNT, EntityType.WITHER_SKULL).addOptional(NeapolitanConstants.TMT);
+		this.tag(NeapolitanEntityTypeTags.SCARES_CHIMPANZEES).add(EntityType.DRAGON_FIREBALL, EntityType.EVOKER_FANGS, EntityType.FIREBALL, EntityType.FIREWORK_ROCKET, EntityType.LIGHTNING_BOLT, EntityType.SMALL_FIREBALL, EntityType.TNT, EntityType.WITHER_SKULL).addOptional(NeapolitanConstants.TMT).addOptional(NeapolitanConstants.SPORE_BOMB);
 		this.tag(NeapolitanEntityTypeTags.UNAFFECTED_BY_HARMONY);
 		this.tag(NeapolitanEntityTypeTags.UNAFFECTED_BY_SLIPPING).add(NeapolitanEntityTypes.CHIMPANZEE.get(), NeapolitanEntityTypes.PLANTAIN_SPIDER.get());
 		this.tag(NeapolitanEntityTypeTags.EXPLOSION_HEALS_IN_STRAWBERRY).add(EntityType.CREEPER).addOptional(NeapolitanConstants.CREEPIE);

--- a/src/main/java/com/teamabnormals/neapolitan/core/other/NeapolitanConstants.java
+++ b/src/main/java/com/teamabnormals/neapolitan/core/other/NeapolitanConstants.java
@@ -26,4 +26,5 @@ public class NeapolitanConstants {
 	public static final ResourceLocation MUD_BALL = new ResourceLocation(ENVIRONMENTAL, "mud_ball");
 	public static final ResourceLocation CREEPIE = new ResourceLocation(SAVAGE_AND_RAVAGE, "creepie");
 	public static final ResourceLocation GRIEFER_HELMET = new ResourceLocation(SAVAGE_AND_RAVAGE, "griefer_helmet");
+	public static final ResourceLocation SPORE_BOMB = new ResourceLocation(SAVAGE_AND_RAVAGE, "spore_bomb");
 }


### PR DESCRIPTION
Very small changes for 1.20.1.

For the milk bottle change, the new implementation does make it that if one un-clearable status effect is targeted by the bottle, it simply won't clear any effects.

this is less than ideal, but the only alternative is to filter the list of active effects using that forge hook's push. implementing this would mean calling the hook multiple times, leading to the potential possibility of:
1. I have three active effects: jump boost, simpering, and radioactivity
2. there are event hooks attached to simpering and radioactivity: let's say that for simpering, on an attempt to remove, the player explodes instead. for radioactivity, the radioactivity level increases.
3. the code tries to stream-filter the entity's active effects on milk bottle consumption. filtering using the forge hook triggers the player's explosion and radioactivity intensification. jump boost is successfully removed, but with two negative, unintended externalities

So that's why the current implementation is what it is. i hope it's acceptable--i still think it makes more sense than clearing that which should not be clearable