### PR TITLE
Fix double namespaces in advancement JSON

### DIFF
--- a/src/generated/resources/data/neapolitan/modifiers/advancements/adventure/adventuring_time.json
+++ b/src/generated/resources/data/neapolitan/modifiers/advancements/adventure/adventuring_time.json
@@ -4,7 +4,7 @@
       "type": "criteria",
       "config": {
         "criteria": {
-          "neapolitan:neapolitan:strawberry_fields": {
+          "neapolitan:strawberry_fields": {
             "conditions": {
               "player": [
                 {
@@ -24,7 +24,7 @@
         "indexed_requirements": [],
         "requirements": [
           [
-            "neapolitan:neapolitan:strawberry_fields"
+            "neapolitan:strawberry_fields"
           ]
         ],
         "should_replace_requirements": false

--- a/src/generated/resources/data/neapolitan/modifiers/advancements/adventure/trim_with_any_armor_pattern.json
+++ b/src/generated/resources/data/neapolitan/modifiers/advancements/adventure/trim_with_any_armor_pattern.json
@@ -4,7 +4,7 @@
       "type": "criteria",
       "config": {
         "criteria": {
-          "neapolitan:armor_trimmed_neapolitan:primal_armor_trim_smithing_template": {
+          "neapolitan:armor_trimmed_primal_armor_trim_smithing_template": {
             "conditions": {
               "recipe_id": "neapolitan:primal_armor_trim_smithing_template"
             },
@@ -16,7 +16,7 @@
             "index": 0,
             "replace": false,
             "requirements": [
-              "neapolitan:armor_trimmed_neapolitan:primal_armor_trim_smithing_template"
+              "neapolitan:armor_trimmed_primal_armor_trim_smithing_template"
             ]
           }
         ],

--- a/src/main/java/com/teamabnormals/neapolitan/core/data/server/NeapolitanAdvancementModifierProvider.java
+++ b/src/main/java/com/teamabnormals/neapolitan/core/data/server/NeapolitanAdvancementModifierProvider.java
@@ -71,7 +71,7 @@ public class NeapolitanAdvancementModifierProvider extends AdvancementModifierPr
 				.addCriterion("banana_plant_rare", LootTableTrigger.TriggerInstance.lootTableUsed(NeapolitanLootTables.BANANA_PLANT_ARCHAEOLOGY_RARE))
 				.addIndexedRequirements(0, false, "banana_plant_common", "banana_plant_rare").build());
 
-		String entry = "armor_trimmed_" + NeapolitanItems.PRIMAL_ARMOR_TRIM_SMITHING_TEMPLATE.getId();
+		String entry = "armor_trimmed_" + NeapolitanItems.PRIMAL_ARMOR_TRIM_SMITHING_TEMPLATE.getId().getPath();
 		this.entry("adventure/trim_with_any_armor_pattern").selects("adventure/trim_with_any_armor_pattern").addModifier(CriteriaModifier.builder(this.modId)
 				.addCriterion(entry, RecipeCraftedTrigger.TriggerInstance.craftedItem(NeapolitanItems.PRIMAL_ARMOR_TRIM_SMITHING_TEMPLATE.getId()))
 				.addIndexedRequirements(0, false, entry).build());

--- a/src/main/java/com/teamabnormals/neapolitan/core/data/server/NeapolitanAdvancementModifierProvider.java
+++ b/src/main/java/com/teamabnormals/neapolitan/core/data/server/NeapolitanAdvancementModifierProvider.java
@@ -63,7 +63,7 @@ public class NeapolitanAdvancementModifierProvider extends AdvancementModifierPr
 
 		RegistryLookup<Biome> biomes = provider.lookupOrThrow(Registries.BIOME);
 		this.entry("adventure/adventuring_time").selects("adventure/adventuring_time").addModifier(CriteriaModifier.builder(this.modId)
-				.addCriterion(NeapolitanBiomes.STRAWBERRY_FIELDS.location().toString(), PlayerTrigger.TriggerInstance.located(LocationPredicate.Builder.inBiome(biomes.getOrThrow(NeapolitanBiomes.STRAWBERRY_FIELDS))))
+				.addCriterion(NeapolitanBiomes.STRAWBERRY_FIELDS.location().getPath(), PlayerTrigger.TriggerInstance.located(LocationPredicate.Builder.inBiome(biomes.getOrThrow(NeapolitanBiomes.STRAWBERRY_FIELDS))))
 				.requirements(Strategy.AND).build());
 
 		this.entry("adventure/salvage_sherd").selects("adventure/salvage_sherd").addModifier(CriteriaModifier.builder(this.modId)


### PR DESCRIPTION
The advancement entry's for the trim smithing template & adventuring time - gives an incorrect ID
Which cause game to crash when player trying to open advancements with advancements enchanter mod(such as [advancements reloaded](https://modrinth.com/mod/advancements-reloaded)) on non LAN server 
The 
"armor_trimmed_" + NeapolitanItems.PRIMAL_ARMOR_TRIM_SMITHING_TEMPLATE.getId()
gives 
neapolitan:armor_trimmed_neapolitan:primal_armor_trim_smithing_template 
instead of 
neapolitan:armor_trimmed_primal_armor_trim_smithing_template

because NeapolitanItems.PRIMAL_ARMOR_TRIM_SMITHING_TEMPLATE.getId() returns full id that leads to double namespace issue, .getPath() returns item name instead of full ID

same with adveturing_time, .ToString() returns full id instead of just name